### PR TITLE
Console 调整

### DIFF
--- a/panel/console.js
+++ b/panel/console.js
@@ -42,7 +42,9 @@ Editor.Panel.extend({
             box-sizing: border-box;
             position: absolute;
             top: 0;
+            font-size: 14px;
             width: 100%;
+            -webkit-user-select: initial;
         }
         section .item[texture=light] {
             background-color:#292929;
@@ -54,7 +56,7 @@ Editor.Panel.extend({
             color: #999;
         }
         section .item[type=error] {
-            color: #c80c0c;
+            color: #DA2121;
         }
         section .item[type=warn] {
             color: #990;
@@ -63,7 +65,7 @@ Editor.Panel.extend({
             color: #090;
         }
         section .item[type=failed] {
-            color: #c80c0c;
+            color: #DA2121;
         }
         section .item[type=success] {
             color: #090;
@@ -92,12 +94,15 @@ Editor.Panel.extend({
             padding-right: 2px;
         }
         section div .info {
-            margin-left: 35px;
+            margin-left: 45px;
         }
         section div .info div {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            line-height: 26px;
+            font-size: 13px;
+            color: #A73637;
         }
     `,
 

--- a/panel/item.js
+++ b/panel/item.js
@@ -19,8 +19,11 @@ exports.template = `
         <span v-if="num>1">{{num}}</span>
     </div>
     <div class="info" v-if="!fold">
-        <template v-for="str in foldInfo">
-            <div>{{str}}</div>
+        <template v-for="item in foldInfo" track-by="$index">
+            <div>
+                <span>{{item.info}}</span>
+                <span class="path">{{item.path}}</span>
+            </div>
         </template>
     </div>
 </div>
@@ -42,12 +45,18 @@ exports.directives = {
         this.vm.style.transform = `translateY(${y}px)`;
     },
     info (info) {
+        var sources = info.split('\n');
         var results = this.vm.foldInfo;
         while (results.length > 0) {
             results.pop();
         }
-        info.split('\n').forEach((item) => {
-            results.push(item.trim());
+        sources.forEach((item) => {
+            var match = item.match(/(at [^ ]+) (.*)/);
+            match = match || ["", item];
+            results.push({
+                info: match[1] || '',
+                path: match[2] || ''
+            });
         });
     }
 };

--- a/panel/list.js
+++ b/panel/list.js
@@ -33,7 +33,7 @@ var getHeight = function (list) {
         if (item.fold) {
             height += 30;
         } else {
-            height += item.rows * 30;
+            height += item.rows * 26 + 4;
         }
     });
     return height;
@@ -77,7 +77,7 @@ exports.methods = {
             if (item.fold) {
                 tmp += 30;
             } else {
-                tmp += item.rows * 30;
+                tmp += item.rows * 26 + 4;
             }
             if (tmp > scroll) {
                 index = i - 1;
@@ -112,7 +112,7 @@ exports.methods = {
 
         var source = this.messages[index++];
         source.fold = fold;
-        var offsetY = source.rows * 30 - 30;
+        var offsetY = source.rows * 26 + 4 - 30;
         if (fold) {
             offsetY = -offsetY;
         }
@@ -159,7 +159,7 @@ exports.directives = {
                 if (item.fold) {
                     tmp += 30;
                 } else {
-                    tmp += item.rows * 30;
+                    tmp += item.rows * 26 + 4;
                 }
                 if (tmp > scroll) {
                     index = i - 1;

--- a/panel/manager.js
+++ b/panel/manager.js
@@ -36,6 +36,12 @@ exports.addItem = function (item) {
     var result = {};
     result.type = item.type;
     var split = item.message.split('\n');
+    split = split.map((item) => {
+        return item.trim();
+    });
+    split = split.filter((item) => {
+        return item !== "";
+    });
     result.rows = split.length; // 默认高度
     result.title = split[0];
     result.info = split.splice(1).join('\n');
@@ -107,7 +113,7 @@ exports.update = function () {
             if (item.fold) {
                 offsetY += 30;
             } else {
-                offsetY += item.rows * 30;
+                offsetY += item.rows * 26 + 4;
             }
         });
     });


### PR DESCRIPTION
- 加大字号，现在正常显示的是 14 号字体，错误信息隐藏的消息是 13 号字体。
- 更改了错误信息的配色，标题和信息显示不同亮度的红色，避免展开多个错误后，整个屏幕都是同一个红色字体。
![image](https://cloud.githubusercontent.com/assets/7113508/17016261/e830b166-4f60-11e6-8584-13f6a0dd1dfa.png)
- 错误信息展开的行高改成了 26，更紧凑一些，之前间隔有点大。
- 修复了如果错误信息内包含空字符的时候 vue 会报错的问题。