### PR TITLE
增加错误信息的横向滚动条

### DIFF
--- a/panel/console.js
+++ b/panel/console.js
@@ -45,6 +45,10 @@ Editor.Panel.extend({
             font-size: 14px;
             width: 100%;
             -webkit-user-select: initial;
+            overflow-x: scroll;
+        }
+        section .item[fold] {
+            overflow-x: hidden;
         }
         section .item[texture=light] {
             background-color:#292929;
@@ -88,20 +92,29 @@ Editor.Panel.extend({
         section div .text {
             position: relative;
             flex: 1;
-            overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
             padding-right: 2px;
         }
+        section div[fold] .text {
+            overflow: hidden;
+        }
         section div .info {
             margin-left: 45px;
         }
+        section div[fold] .info > div {
+            display: none;
+        }
         section div .info div {
             white-space: nowrap;
-            overflow: hidden;
             text-overflow: ellipsis;
             line-height: 26px;
             font-size: 13px;
+        }
+        section div[fold] .info div {
+            overflow: hidden;
+        }
+        section .item[type=error] .info div {
             color: #A73637;
         }
     `,

--- a/panel/console.js
+++ b/panel/console.js
@@ -75,15 +75,15 @@ Editor.Panel.extend({
             color: #090;
         }
         section .item i {
-            padding: 0 4px;
         }
         section .item i.fold {
             color: #555;
             cursor: pointer;
-            padding: 0;
+            padding: 2px;
         }
         section .item i.fa-caret-right {
-            padding: 0 1px;
+            padding: 2px 5px 2px 6px;
+            margin: 0 -2px;
         }
         
         section div .warp {

--- a/panel/item.js
+++ b/panel/item.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.template = `
-<div class="item" v-bind:type="type" v-init="y" v-info="info" v-bind:style="style" v-bind:texture="texture">
+<div class="item" v-bind:type="type" v-init="y" v-info="info" v-bind:style="style" v-bind:texture="texture" v-bind:fold="fold">
     <div class="warp">
         <div class="text">
             <span>
@@ -18,7 +18,7 @@ exports.template = `
         </div>
         <span v-if="num>1">{{num}}</span>
     </div>
-    <div class="info" v-if="!fold">
+    <div class="info">
         <template v-for="item in foldInfo" track-by="$index">
             <div>
                 <span>{{item.info}}</span>

--- a/panel/list.js
+++ b/panel/list.js
@@ -33,7 +33,7 @@ var getHeight = function (list) {
         if (item.fold) {
             height += 30;
         } else {
-            height += item.rows * 26 + 4;
+            height += item.rows * 26 + 14;
         }
     });
     return height;
@@ -77,7 +77,7 @@ exports.methods = {
             if (item.fold) {
                 tmp += 30;
             } else {
-                tmp += item.rows * 26 + 4;
+                tmp += item.rows * 26 + 14;
             }
             if (tmp > scroll) {
                 index = i - 1;
@@ -112,7 +112,7 @@ exports.methods = {
 
         var source = this.messages[index++];
         source.fold = fold;
-        var offsetY = source.rows * 26 + 4 - 30;
+        var offsetY = source.rows * 26 + 14 - 30;
         if (fold) {
             offsetY = -offsetY;
         }
@@ -159,7 +159,7 @@ exports.directives = {
                 if (item.fold) {
                     tmp += 30;
                 } else {
-                    tmp += item.rows * 26 + 4;
+                    tmp += item.rows * 26 + 14;
                 }
                 if (tmp > scroll) {
                     index = i - 1;

--- a/panel/manager.js
+++ b/panel/manager.js
@@ -113,7 +113,7 @@ exports.update = function () {
             if (item.fold) {
                 offsetY += 30;
             } else {
-                offsetY += item.rows * 26 + 4;
+                offsetY += item.rows * 26 + 14;
             }
         });
     });


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7113508/17019519/40bdf25e-4f6f-11e6-9b9e-baf61b896271.png)

在展开状态下，显示heng'xiang横向滚动条。因为有些用户需要复制或者查看完整的log信息，在信息过长的情况下就会被隐藏。

- 展开状态下增加横向滚动条
- 错误信息前面的下拉箭头体积增大，点击面加大