### PR TITLE
修复 console 部分问题

### DIFF
--- a/panel/list.js
+++ b/panel/list.js
@@ -61,7 +61,7 @@ var createItem = function () {
         texture: 'dark',
         fold: true,
         num: 1,
-        translateY: -1000
+        translateY: -10000
     };
 };
 
@@ -88,7 +88,7 @@ exports.methods = {
         dataList.forEach(function (item, i) {
             var source = list[index + i];
             if (!source) {
-                item.translateY = -1000;
+                item.translateY = -10000;
                 return;
             }
             item.type = source.type;
@@ -156,12 +156,12 @@ exports.directives = {
             var tc = this.vm.$el.clientHeight;
             var cn = list.length - scrollNumCache;
             scrollNumCache = list.length;
-            if (ts !== 0 && height - tc -ts > 30 * cn) {
-                return this.vm.onScroll({ target: this.vm.$el });
+
+            var scroll = height - tc;
+
+            if (ts === 0 || height - tc -ts <= 30 * cn) {
+                this.vm.$el.scrollTop = scroll;
             }
-
-
-            var scroll = this.vm.$el.scrollTop = height - tc;
 
             var tmp = 0;
             var index = 0;
@@ -181,7 +181,7 @@ exports.directives = {
                 if (!dataList[i])
                     dataList.push(createItem());
                 else
-                    dataList[i].translateY = -1000;
+                    dataList[i].translateY = -10000;
             }
 
             this.vm.onScroll({ target: this.vm.$el });


### PR DESCRIPTION
修复以下两个问题：

- 之前隐藏的 item 只向上移动 1000 像素，如果碰到怪蜀黍，一个 log 超过 34 行，则会显示在页面上。现在改成向上挪动 10000 像素。如果一个 log 超过 334 行。。。能不能不管他。。。

- 滚动条不在头和尾的情况下，更新 log item 的逻辑会被被中断，这时候如果改变 console 高度，则 item 不会生成。。。